### PR TITLE
Disabling HT for training

### DIFF
--- a/src/common/cpuid.h
+++ b/src/common/cpuid.h
@@ -1,0 +1,34 @@
+#ifndef CPUID_H
+#define CPUID_H
+
+#ifdef _WIN32
+  #include <limits.h>
+  #include <intrin.h>
+  typedef unsigned __int32  uint32_t;
+#else
+  #include <stdint.h>
+#endif
+
+class CPUID {
+ public:
+  explicit CPUID(unsigned i) {
+    #ifdef _WIN32
+      __cpuid((int *)regs, (int)i);
+    #else
+      asm volatile
+        ("cpuid" : "=a" (regs[0]), "=b" (regs[1]), "=c" (regs[2]), "=d" (regs[3])
+         : "a" (i), "c" (0));
+      // ECX is set to zero for CPUID function 4
+    #endif
+  }
+
+  const uint32_t& EAX() const { return regs[0]; }
+  const uint32_t& EBX() const { return regs[1]; }
+  const uint32_t& ECX() const { return regs[2]; }
+  const uint32_t& EDX() const { return regs[3]; }
+
+ protected:
+  uint32_t regs[4];
+};
+
+#endif // CPUID_H


### PR DESCRIPTION
At the moment, if the number of threads is not specified by the user (that is a very popular case), XGBoost uses `omp_num_procs` threads which includes HT. Many of our measurements show that in this case, the training section is slower than without HT. This is probably due to the fact that the training stage involves very intensive calculations.
The opposite can be said about the prediction stage. Hyper-threading noticeably accelerates it.
Here are some of our measurements:

// TODO: Add tables with measurements